### PR TITLE
 feat(nvim): plain PHP stack 

### DIFF
--- a/coc-settings.json
+++ b/coc-settings.json
@@ -46,6 +46,9 @@
     "vue-html": "html",
     "vue": "html"
   },
+  "intelephense.environment.phpVersion": "8.5.0",
   "intelephense.files.maxSize": 5000000,
+  "intelephense.diagnostics.enable": true,
+  "intelephense.format.enable": false,
   "php-cs-fixer.rules": "@PSR12"
 }

--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -260,6 +260,7 @@ function M.setup()
 		sass = true,
 		haskell = true,
 		html = true,
+		php = true,
 	}
 	vim.api.nvim_create_autocmd("BufWritePre", {
 		group = aug,

--- a/lua/plugins/ale.lua
+++ b/lua/plugins/ale.lua
@@ -15,6 +15,14 @@ return {
 				jsx = { "css", "javascript" },
 				vue = { "javascript", "vue" },
 			}
+			local composer_bin = vim.fn.expand("~/.config/composer/vendor/bin")
+			if vim.fn.executable(composer_bin .. "/phpcs") == 1 then
+				vim.g.ale_php_phpcs_executable = composer_bin .. "/phpcs"
+				vim.g.ale_php_phpcbf_executable = composer_bin .. "/phpcbf"
+				vim.g.ale_php_phpcs_standard = "PSR12"
+				vim.g.ale_php_phpcbf_standard = "PSR12"
+			end
+
 			vim.g.ale_linters = {
 				-- eslint only for JS/TS stack — tsserver from coc-tsserver-dev / Volar
 				javascript = { "eslint" },

--- a/lua/plugins/languages.lua
+++ b/lua/plugins/languages.lua
@@ -48,6 +48,7 @@ return {
 				"coc-yank",
 				"coc-markdown-preview-enhanced",
 				"coc-blade",
+				"@yaegassy/coc-intelephense",
 				"coc-fzf-preview",
 				"coc-cssmodules",
 				"coc-docker",
@@ -215,6 +216,7 @@ return {
 				"bash",
 				"markdown",
 				"markdown_inline",
+				"php",
 				"vue",
 			}
 			local ts_enabled = {}


### PR DESCRIPTION
  - @yaegassy/coc-intelephense + intelephense settings (PHP 8.5, format off)
  - treesitter php in highlight whitelist
  - ALE: composer global phpcs/phpcbf path + PSR12 standard
  - trim trailing whitespace on save for php buffers